### PR TITLE
Fixing agent app download failure in iOS 7.1

### DIFF
--- a/modules/apps/mdm/modules/device.js
+++ b/modules/apps/mdm/modules/device.js
@@ -717,11 +717,11 @@ var device = (function () {
             if (userAgent.indexOf("Android") > 0) {
                 return (configFile.device.android_location);
             } else if (userAgent.indexOf("iPhone") > 0) {
-                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTP_URL + "/mdm/api/devices/ios/download");
+                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTPS_URL + "/mdm/api/devices/ios/download");
             } else if (userAgent.indexOf("iPad") > 0){
-                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTP_URL + "/mdm/api/devices/ios/download");
+                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTPS_URL + "/mdm/api/devices/ios/download");
             } else if (userAgent.indexOf("iPod") > 0){
-                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTP_URL + "/mdm/api/devices/ios/download");
+                return("itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=" + configFile.HTTPS_URL + "/mdm/api/devices/ios/download");
             }
         },
 


### PR DESCRIPTION
Fixing agent app download failure in iOS 7.1. iOS 7.1 requires you to download the apps in https mode. 
